### PR TITLE
Fixing component initiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can use the following snippets in JavaScript.
 
           angular
               .module('${1:module}')
-              .component('${2:component}', ${2:component});
+              .component('${2:component}', ${2:component}());
 
           /* @ngInject */
           function ${2:component}() {

--- a/snippets/ngcomponent.cson
+++ b/snippets/ngcomponent.cson
@@ -7,7 +7,7 @@
 
           angular
               .module('${1:module}')
-              .component('${2:component}', ${2:component});
+              .component('${2:component}', ${2:component}());
 
           /* @ngInject */
           function ${2:component}() {


### PR DESCRIPTION
Component does not have factory initiation like directives.
From [documentation](https://docs.angularjs.org/guide/component): 
`
The Component config object. (Note that, unlike the .directive() method, this method does not take a factory function.)
`
